### PR TITLE
Lint entrypoint.py

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,14 @@ name: PR
 on: pull_request
 
 jobs:
+  lint-entrypoint-py:
+    name: Lint entrypoint.py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: pylint
+        run: make pylint
+
   superlinter:
     name: Lint bash, docker, markdown, and yaml
     runs-on: ubuntu-latest
@@ -24,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Docker build
-        run: "docker build --pull ."
+        run: make build
 
   verify-changelog:
     name: Verify CHANGELOG is valid

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN apk add --update --no-cache \
   git \
   py3-pip
 
-RUN pip3 install gitpython PyGithub
+RUN pip3 install \
+  gitpython \
+  PyGithub \
+  pylint
 
 ENTRYPOINT ["/entrypoint.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+TAG := docker.pkg.github.com/ponylang/release-notes-reminder-bot-action/release-notes-reminder-bot:latest
+
+all: build
+
+build:
+	docker build --pull -t ${TAG} .
+
+pylint: build
+	docker run --entrypoint pylint --rm ${TAG} /entrypoint.py
+
+.PHONY: build pylint


### PR DESCRIPTION
Sets up linting of entrypoint.py. I previously tried to do using
GitHub's superlinter, however, being able to use Python linters
with the required dependencies is a bit of a nightmare.

This update includes pylink in the same docker container that our
action normally runs in making it easy to build for both running
and for linting of the code.

Also included is a Makefile that currently allows for building
the container as well as linting it via two targets:

- build
- pylint

The Makefile is a first step towards being able to build fixed containers
on release and use those rather than rebuilding each time the action is
used for actions in various workflows. I'm planning on hosting those
released versions in GitHub packages, thus the stub "tag" in the Makefile
referencing the GitHub packages url. The name in the tag is currently unimportant
and can be ignored until such time as a push action is added to Makefile at
which point the tag name will become "real".

This commit also includes changes to entrypoint.py needed to get it to pass
the pylint linting.