### PR TITLE
Updated base image

### DIFF
--- a/.release-notes/new-alpine.md
+++ b/.release-notes/new-alpine.md
@@ -1,0 +1,3 @@
+## Updated base image
+
+We've updated our base image from Alpine 3.12 to 3.16. Alpine 3.12 is no longer supported.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16
 
 COPY entrypoint.py /entrypoint.py
 


### PR DESCRIPTION
We've updated our base image from Alpine 3.12 to 3.16. Alpine 3.12 is no longer
supported.